### PR TITLE
pageRender now returns empty app on error

### DIFF
--- a/server/render/pageRenderer.jsx
+++ b/server/render/pageRenderer.jsx
@@ -4,11 +4,18 @@ import { Provider } from 'react-redux';
 import { RouterContext } from 'react-router';
 import Helmet from 'react-helmet';
 
-const createApp = (store, props) => renderToString(
-  <Provider store={store}>
-    <RouterContext {...props} />
-  </Provider>
-);
+const createApp = (store, props) => {
+  try {
+    return renderToString(
+      <Provider store={store}>
+        <RouterContext {...props} />
+      </Provider>
+    );
+  } catch (err) {
+    console.error(err);
+    return '';
+  }
+};
 
 const styles = process.env.NODE_ENV === 'production' ? '<link rel="stylesheet" href="/assets/css/styles.css">' : '';
 


### PR DESCRIPTION
When you get an error in the Universal Rendering it would return a JSON object previously, now it returns an empty app so that the client side renders the page and gets the error too for better/more understandable error messages in the browser.