### PR TITLE
Added support for promises (used with axios requests to WP) for IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-plugin-transform-react-constant-elements": "^6.5.0",
     "babel-plugin-transform-react-inline-elements": "^6.6.5",
     "babel-plugin-transform-react-remove-prop-types": "^0.2.3",
+    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-react-hmre": "^1.1.1",
@@ -75,6 +76,7 @@
     "react-router": "^2.7.0",
     "react-router-redux": "^4.0.0",
     "react-transform-hmr": "^1.0.4",
+    "redis": "^2.7.1",
     "redux": "^3.6.0",
     "redux-logger": "^2.6.1",
     "redux-thunk": "^2.0.1",
@@ -85,7 +87,6 @@
     "url-loader": "^0.5.7",
     "webpack": "^1.13.2",
     "webpack-dev-middleware": "^1.5.1",
-    "webpack-hot-middleware": "^2.12.2",
-    "redis": "^2.7.1"
+    "webpack-hot-middleware": "^2.12.2"
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import express from 'express';
 import webpack from 'webpack';
 import { isDebug } from '../config/app';

--- a/webpack/webpack.config.dev-client.js
+++ b/webpack/webpack.config.dev-client.js
@@ -74,7 +74,7 @@ module.exports = {
     // Multiple entry with hot loader
     // https://github.com/glenjamin/webpack-hot-middleware/blob/master/example/webpack.config.multientry.js
     entry: {
-      app: ['./client', hotMiddlewareScript]
+      app: ['babel-polyfill', './client', hotMiddlewareScript]
     },
     output: {
       // The output directory as absolute path

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -36,7 +36,7 @@ module.exports = [
     devtool: 'cheap-module-source-map',
     context: path.join(__dirname, '..', 'app'),
     entry: {
-      app: './client'
+      app: ['babel-polyfill','./client']
     },
     output: {
       // The output directory as absolute path

--- a/yarn.lock
+++ b/yarn.lock
@@ -838,6 +838,14 @@ babel-polyfill@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+babel-polyfill@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
+  dependencies:
+    babel-runtime "^6.22.0"
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
 babel-preset-es2015@^6.14.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.22.0.tgz#af5a98ecb35eb8af764ad8a5a05eb36dc4386835"


### PR DESCRIPTION
@samlogan 

Hey Sam,

babel-polyfill (https://babeljs.io/docs/usage/polyfill/) worked well for me when making Cascada IE11 compatible, primarily allowing the use of promises.

I noticed today that you've previously used Bluebird previously as a polyfill for the same (https://github.com/petkaantonov/bluebird).

I think one of these two libraries should be used to make starward IE11 compatible out of the box!

Cheers, Allan