### PR TITLE
Updating nodemon to watch assets folder for SASS and images for live …

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,7 @@
 {
     "verbose": false,
     "watch": [
+      "public/assets",
       "app/utils",
       "app/fetch-data",
       "app/client.jsx",


### PR DESCRIPTION
This is an *awesome* boilerplate and has really sped up my react/wp-api development ... but coming from create-react-app I was a total loss as to while style change weren't appearing in the dev server. Took me (probably too long) to figure out I needed to add "public/assets" to the nodemon.json file. Perhaps it makes more sense to have that folder watched by default?