### PR TITLE
Removed user scaling

### DIFF
--- a/app/components/Common/Head.jsx
+++ b/app/components/Common/Head.jsx
@@ -15,7 +15,7 @@ export const Head = (props) => {
   const ogTitle = props['opengraph-title'];
 
   const meta = [
-    {name: 'viewport', content: 'width=device-width, initial-scale=1.0'},
+    {name: 'viewport', content: 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0'},
     {name: 'description', content: metadesc },
     {property: 'og:type', content: 'website'},
     {property: 'og:title', content: !ogTitle ? title : ogTitle},


### PR DESCRIPTION
sometimes on mobile an input field can make your browser zoom in to focus on the input, this stops mobile from doing this zoom input focus thing