### PR TITLE
Fixed noindex and nofollow

### DIFF
--- a/app/components/Common/Head.jsx
+++ b/app/components/Common/Head.jsx
@@ -21,9 +21,15 @@ export const Head = (props) => {
     {property: 'og:title', content: !ogTitle ? title : ogTitle},
     {property: 'og:description', content: !ogDescription ? metadesc : ogDescription},
     {property: 'og:image', content: ogImage},
-    {property: 'robots', content: noindex},
-    {property: 'robots', content: nofollow}
   ];
+  
+  if (noindex && nofollow) {
+    meta.push({name: 'robots', content: 'noindex,nofollow'});
+  } else if (noindex) {
+    meta.push({name: 'robots', content: 'noindex'});
+  } else if (nofollow) {
+    meta.push({name: 'robots', content: 'nofollow'});
+  }
 
   const links = [
     {rel: 'canonical', href: canonical },


### PR DESCRIPTION
as par this documentation: http://www.robotstxt.org/meta.html
you can see that the following is expected:
<meta name="robots" content="noindex,nofollow"/>

Whereas we do two things wrong:
<meta property="robots" content="noindex"/>
<meta property="robots" content="nofollow"/>

1. we use property and not name
2. we create two elements rather than a single seperated by comma.

The output of this now matches what yoast makes on a normal WP site.