### PR TITLE
add yarn.lock to .gitingore exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *~
 *.sass-cache
 *.lock
+!yarn.lock
 
 # OS or Editor folders
 __MACOSX/


### PR DESCRIPTION
not commiting yarn.lock is a mistake. It's used to make sure the dependancies tested and ran on local match staging/production