### PR TITLE
defer'd scripts so that they don't pause DOM

### DIFF
--- a/server/render/pageRenderer.jsx
+++ b/server/render/pageRenderer.jsx
@@ -32,7 +32,7 @@ const buildPage = ({ componentHTML, initialState, headAssets }) => {
   <body>
     <div id="app">${componentHTML}</div>
     <script>window.__INITIAL_STATE__ = ${JSON.stringify(initialState)}</script>
-    <script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,es6" defer></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6" defer></script>
     <script type="text/javascript" charset="utf-8" src="/assets/app.js" defer></script>
   </body>
 </html>`;

--- a/server/render/pageRenderer.jsx
+++ b/server/render/pageRenderer.jsx
@@ -32,8 +32,8 @@ const buildPage = ({ componentHTML, initialState, headAssets }) => {
   <body>
     <div id="app">${componentHTML}</div>
     <script>window.__INITIAL_STATE__ = ${JSON.stringify(initialState)}</script>
-    <script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,es6"></script>
-    <script type="text/javascript" charset="utf-8" src="/assets/app.js"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,es6" defer></script>
+    <script type="text/javascript" charset="utf-8" src="/assets/app.js" defer></script>
   </body>
 </html>`;
 };


### PR DESCRIPTION
adding defer to a script tag allows the DOM to keep parsing whilest it fetches the resources + it will still execute in the correct order!