### PR TITLE
removed PropTypes from Post Categories

### DIFF
--- a/app/components/Common/Navigation.jsx
+++ b/app/components/Common/Navigation.jsx
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { NavLink } from 'react-router-dom';
 
 const NavigationLink = ({ item }) => {

--- a/app/components/Posts/PostCategories.jsx
+++ b/app/components/Posts/PostCategories.jsx
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 export const PostCategories = (props) => {


### PR DESCRIPTION
PropTypes is no longer inside of the react package so if we want to use it we need to install it. This is a choice that can be made by the developer who is building the site.