### PR TITLE
Illegal character Regex updated

### DIFF
--- a/server/config/app-template.js
+++ b/server/config/app-template.js
@@ -8,4 +8,4 @@ export const GRAVITY_PRIVATE = 'Add private key from gravity forms settings';
 export const REDIS_PREFIX = null; // change me to your project name, for example: 'starward-'
 
 // General
-export const characterBlacklistRegex = /[^\w\s]/gi;
+export const characterBlacklistRegex = /[^a-z0-9\\[\\]]/gi;

--- a/server/config/app-template.js
+++ b/server/config/app-template.js
@@ -8,4 +8,4 @@ export const GRAVITY_PRIVATE = 'Add private key from gravity forms settings';
 export const REDIS_PREFIX = null; // change me to your project name, for example: 'starward-'
 
 // General
-export const serversideStateCharacterBlacklistRegex = /\u2028/g;
+export const characterBlacklistRegex = /[^\w\s]/gi;

--- a/server/init/api.js
+++ b/server/init/api.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { appSettings, gravityForms, wp } from '../../graphQL';
-import { serversideStateCharacterBlacklistRegex, WP_URL, REDIS_PREFIX } from '../config/app';
+import { characterBlacklistRegex, WP_URL, REDIS_PREFIX } from '../config/app';
 import { createRedisClient } from '../redis';
 import { submitForm } from './gravitySubmit';
 
@@ -15,7 +15,7 @@ const sanitizeJSON = (json) => {
   const wpUrlRegex = new RegExp(WP_URL, 'g');
   const wpContentUrlRegex = new RegExp('/wp-content', 'g');
   const cleaned = stringified
-  .replace(serversideStateCharacterBlacklistRegex, '')
+  .replace(characterBlacklistRegex, '')
   .replace(wpUrlRegex, '')
   .replace(wpContentUrlRegex, `${WP_URL}/wp-content`);
   return JSON.parse(cleaned);


### PR DESCRIPTION
@chungeric and @markmollart have recently encountered issues with illegal characters from the WP WYSIWYG editor crashing the Starward API.

I have updated the Regex but it is hard to test without any offending copy to hand. Anyone have any recommendations, is the commit code better than the previous approach, it was ripped from [here](https://stackoverflow.com/questions/4374822/remove-all-special-characters-with-regexp) and [here](https://stackoverflow.com/questions/4374822/remove-all-special-characters-with-regexp).

Is anyone able to test with a recent offender from Sketch or similar?