### PR TITLE
added utility to extract WP images from ACF values

### DIFF
--- a/app/config/app-template.js
+++ b/app/config/app-template.js
@@ -11,6 +11,9 @@ export const SEARCH_SLUG = 'search';
 
 // Starward
 export const baseURL = `http://${HOST}:${PORT}`;
+export const WP_URL = 'http://localhost/starward_wp';
+export const WP_RESOURCE_URL = WP_URL; // change to '' and images will attempt to resolve to the app host, then if you have nginx setup you can proxy the WP through the APP hosting's address
+//                                        This is useful when you proxy the /feed/ endpoint of WP and re-write all wp.somesite.com to somesite.com as the images also will get re-written, not just the links
 
 // GraphQL
 export const ROOT_API = `${baseURL}/api`;

--- a/app/utils/starward.js
+++ b/app/utils/starward.js
@@ -1,0 +1,57 @@
+import { WP_RESOURCE_URL } from '../config/app';
+
+const joinResourceUrlToWp = (wpUrl) => `${WP_RESOURCE_URL}${wpUrl}`;
+
+const safeAccessImageProp = (propertyName) => (image) => {
+	if (!image) {
+		return null;
+	}
+	return image[propertyName];
+}
+
+const defaultExtractor = image => image;
+
+export const getBasicWpImageUrl = (image) => {
+	if (!image) {
+		return null;
+	}
+	return joinResourceUrlToWp(image.url);
+};
+
+export const curryExtractWpImageUrl = urlExtractor => (image, size, autoOptimise) => {
+	return extractWpImageUrl(image, size, autoOptimise, urlExtractor);
+};
+
+// Given a WP image from the API, extract the given size (thumbnail name as seen in the API response)
+// you can ignore autoOptimise and urlExtractor as they're for more complicated usage
+//
+// example usage:
+// // I would place all the thumbnail sizes in a constants file I can reference normally to avoid typos
+// const WP_SIZE_MEDIUM_LARGE = 'medium_large';
+// const mediumLargeThumb = extractWpImageUrl(someImageProp, WP_SIZE_MEDIUM_LARGE);
+//
+//
+export const extractWpImageUrl = (image, size, autoOptimise = true, urlExtractor = defaultExtractor) => {
+	if (!autoOptimise || !size || !image) {
+		return getBasicWpImageUrl(image);
+	}
+
+	const sizeUrl = image.sizes[size];
+	if (!sizeUrl) {
+		return getBasicWpImageUrl(image);
+	}
+	return joinResourceUrlToWp(urlExtractor(sizeUrl));
+};
+
+// applies extractWpImageUrl to a map, i.e: someArrayOfWpImages.map(mapExtractWpImageUrl(WP_SIZE_MEDIUM_LARGE))
+// this would get all of the medium large images
+export const mapExtractWpImageUrl = (size, autoOptimise = true) => image => {
+	return extractWpImageUrl(image, size, autoOptimise);
+};
+
+// featured images have different properties that expose the url's so we need to use a custom extractor
+export const extractWpFeaturedImageUrl = curryExtractWpImageUrl(image => image.source_url);
+
+export const getWpImageAlt = safeAccessImageProp('alt');
+
+export const getWpImageCaption = safeAccessImageProp('caption');

--- a/server/config/app-template.js
+++ b/server/config/app-template.js
@@ -1,5 +1,7 @@
+import { WP_URL as APP_WP_URL } from '../../app/config/app.js'
+
 // Wordpress
-export const WP_URL = 'http://localhost/starward_wp';
+export const WP_URL = APP_WP_URL;
 export const WP_API = `${WP_URL}/wp-json`;
 export const GRAVITY_PUBLIC = 'Add public key from gravity forms settings';
 export const GRAVITY_PRIVATE = 'Add private key from gravity forms settings';


### PR DESCRIPTION
###Adds a utility that streamlines extracting WP images from ACF in such a way that allows for:

1. Extracting the raw URL
2. Extract Thumnail URL's
3. Map Extract Thumbnail/raw URL's
4. Extract Featured Images
5. Extract captions
6. Extract alt tag

###Example usages:
####extractWpImageUrl
```
const WP_SIZE_MEDIUM_LARGE = 'medium_large'; // this would be defined in a constants.js file
const mediumLargeThumb = extractWpImageUrl(someImageProp, WP_SIZE_MEDIUM_LARGE);
```

####mapExtractWpImageUrl
```
const listOfMediumLargeThumbnailURLs = someArrayOfWpImages.map(mapExtractWpImageUrl(WP_SIZE_MEDIUM_LARGE))
```

####extractWpFeaturedImageUrl
same as `extractWpImageUrl`, except it works on featured images 

####getWpImageAlt
```
const imgAlt = getWpImageAlt(someImageProp);
```

####getWpImageCaption
```
const imgCaption = getWpImageCaption(someImageProp);
```

By doing this we standardise how we are extracting image URL's and Thumbnails for easier usage by developers. It would be recomended practice that the ACF component extracts the image url or array of url's before passing it down to lower level components as that lets us remove the idea of WP/ACF from our components, thus making them simpler (i.e. in your acf/Hero.js extract the image url's then feed them to the slider as URL's not as WP/ACF objects.

Also do note the new config item of `WP_RESOURCE_URL` this allows us to configure the location of the images to be either the WP location (this will be used in local dev) or we can change it to be an external CDN OR if we need to proxy the images through NGINX (if we are exposing /feed/ or sitemap.xml on WP via proxying we also need to proxy images otherwise the re-writing of wp.somesite.com will leave 404's for the images). If you were to be proxying the images via nginx you would just change this variable to be `WP_RESOURCE_URL = ''`

I have a bunch more utility functions i can upload, however for now this is a really important one to standardise on.