### PR TITLE
Strategically placed Loader to prevent jankyness @ initial page load

### DIFF
--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -6,6 +6,7 @@ import {
   SEARCH_SLUG
 } from './config/app';
 import { fetchWPData } from './fetch-data';
+import { Loading } from './components/Content/Loading';
 import App from './containers/App';
 
 function asyncComponent(getComponent) {
@@ -27,7 +28,7 @@ function asyncComponent(getComponent) {
       if (Component) {
         return <Component {...this.props} />;
       }
-      return null;
+      return <Loading />;
     }
   };
 }


### PR DESCRIPTION
Hey guys, some of the feedback from RYIFY design review was some janky-ness on initial page load. Specifically, something to the description of a Footer flying around everywhere.

This is what fixed it, and I'd wager it's a worthwhile out-of-the-box fix for Starward.

It essentially plants a `<Loading />` (previously `null`) that fills the gap between the Header and Footer until the page components have been fetched from WP.

*Before:*
```
function asyncComponent(getComponent) {
  return class AsyncComponent extends React.Component {
    static Component = null;
    state = { Component: AsyncComponent.Component };

    componentWillMount() {
      if (!this.state.Component) {
        getComponent().then(({ default: Component }) => {
          AsyncComponent.Component = Component;
          this.setState({ Component });
        }).catch(err => console.error(err));
      }
    }

    render() {
      const { Component } = this.state;
      if (Component) {
        return <Component {...this.props} />;
      }
      return null;
    }
  };
}
```

*After:*
```
function asyncComponent(getComponent) {
  return class AsyncComponent extends React.Component {
    static Component = null;
    state = { Component: AsyncComponent.Component };

    componentWillMount() {
      if (!this.state.Component) {
        getComponent().then(({ default: Component }) => {
          AsyncComponent.Component = Component;
          this.setState({ Component });
        }).catch(err => console.error(err));
      }
    }

    render() {
      const { Component } = this.state;
      if (Component) {
        return <Component {...this.props} />;
      }
      return <Loading />; // <--- 👋Hi, I'm new here!
    }
  };
}
```