### PR TITLE
Added better source-mapping

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -22,7 +22,6 @@ module.exports = (env = {}) => {
 
   const prodServerRender = {
     mode: 'production',
-    devtool: 'source-map',
     context: PATHS.app,
     entry: { server: ['babel-polyfill', '../server/index'] },
     target: 'node',
@@ -41,7 +40,6 @@ module.exports = (env = {}) => {
 
   const prodBrowserRender = {
     mode: 'production',
-    devtool: 'cheap-module-source-map',
     context: PATHS.app,
     entry: { app: ['babel-polyfill', './client'] },
     node,
@@ -58,7 +56,7 @@ module.exports = (env = {}) => {
 
   const devBrowserRender = {
     mode: 'development',
-    devtool: 'eval',
+    devtool: 'eval-source-map',
     context: PATHS.app,
     entry: { app: ['babel-polyfill', 'react-hot-loader/patch', './client', hotMiddlewareScript] },
     node,
@@ -74,7 +72,7 @@ module.exports = (env = {}) => {
 
   const devServerRender = {
     mode: 'development',
-    devtool: 'sourcemap',
+    devtool: 'source-map',
     context: PATHS.app,
     entry: { server: ['babel-polyfill', '../server/index'] },
     target: 'node',


### PR DESCRIPTION
I am a developer that lives on my debugger. When we swapped over to React 16 it looks like we changed the dev tools to be cheaper for build time but at the cost of the ability to easily debug.

Specifically the devtool for dev browser renderer was changed to one that uses eval, so files are split in the chrome debugger, but they come through compiled :( for that reason I propose changing it to 'eval-source-map' which also uses eval, but can be translated back into a source file so I can be :) (slow initial build, but fastish re-build!) It is also the recommended dev time source map according to the docs: https://webpack.js.org/configuration/devtool/

I've also updated the dev server devtool to `source-map` as it's the correct spelling (`sourcemap` works but it's not correct)

I also have removed devtool source maps from production as we are not using a error logging service so we have 0 gain having source maps other than slower build times.