### PR TITLE
Using redux-beacon for GTM event handling

### DIFF
--- a/app/actions/gravityforms.js
+++ b/app/actions/gravityforms.js
@@ -28,13 +28,13 @@ export function updateForm(value, id, valid, formId) {
   return ({ type: UPDATE_FORM, payload: {value, id, valid}, key: formId });
 }
 
-export function submitForm(id, fields) {
+export function submitForm(id, fields, formTitle) {
   return (dispatch) => {
     dispatch({ type: SUBMIT_FORM, key: id });
     const gravityFormPostUrl = `${ROOT_API}/gravityforms?id=${id}`;
     axios.post(gravityFormPostUrl, fields)
     .then(({data}) => {
-      if (data.success) dispatch({type: SUBMIT_FORM_SUCCESS, key: id });
+      if (data.success) dispatch({type: SUBMIT_FORM_SUCCESS, key: id, formTitle });
     })
     .catch(() => dispatch({type: SUBMIT_FORM_FAILURE, key: id}));
   };

--- a/app/components/GravityForm/Form.jsx
+++ b/app/components/GravityForm/Form.jsx
@@ -37,7 +37,9 @@ class GravityForm extends Component {
     const { formId, gravityforms } = this.props;
     if (gravityforms[formId].isValid) {
       this.setState({submitFailed: false});
-      this.props.submitForm(formId, gravityforms[formId].formValues);
+      const { formValues, activeForm } = gravityforms[formId] || {};
+      const { title } = activeForm || {};
+      this.props.submitForm(formId, formValues, title);
     } else this.setState({submitFailed: true});
   }
   render() {

--- a/app/utils/configureStore.js
+++ b/app/utils/configureStore.js
@@ -12,8 +12,15 @@ import { gtmMiddleware } from './gtmMiddleware';
  * while using browserHistory for client-side rendering.
  */
 export default function configureStore(initialState, history) {
+  const { starward } = initialState || {};
+  const { settings } = starward || {};
+  const { trackingId } = settings || {};
   // Installs hooks that always keep react-router and redux store in sync
-  const middleware = [thunk, routerMiddleware(history), gtmMiddleware];
+  const middleware = [thunk, routerMiddleware(history)];
+  // Add Google Tag Manager event tracking middleware if trackingId exists
+  if (trackingId) {
+    middleware.push(gtmMiddleware);
+  }
   let store;
 
   if (isClient && isDebug) {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "node": "4.x || 5.x || 6.x || 7.x || 8.x || 9.x"
   },
   "dependencies": {
+    "@redux-beacon/google-tag-manager": "^1.0.1",
     "axios": "^0.16.2",
     "body-parser": "^1.17.2",
     "compression": "^1.7.0",
@@ -81,6 +82,7 @@
     "react-router-redux": "^5.0.0-alpha.6",
     "redis": "^2.7.1",
     "redux": "^3.7.2",
+    "redux-beacon": "^2.0.3",
     "redux-thunk": "^2.0.1",
     "serialize-javascript": "^1.5.0",
     "webpack": "^4.1.0",

--- a/server/render/pageRenderer.jsx
+++ b/server/render/pageRenderer.jsx
@@ -3,6 +3,9 @@ import serialize from 'serialize-javascript';
 import staticAssets from './static-assets/index';
 
 const buildPage = ({ componentHTML, initialState, headAssets }) => {
+  const { starward } = initialState || {};
+  const { settings } = starward || {};
+  const { trackingId } = settings || {};
   return `
 <!doctype html>
 <html>
@@ -11,9 +14,12 @@ const buildPage = ({ componentHTML, initialState, headAssets }) => {
     ${headAssets.meta.toString()}
     ${headAssets.link.toString()}
     ${staticAssets.createStylesheets()}
-    ${staticAssets.createTrackingScript()}
+    ${staticAssets.createTrackingScript(trackingId)}
   </head>
   <body>
+    ${trackingId ?
+    `<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${trackingId}"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>` : ''}
     <div id="app">${componentHTML}</div>
     <script>window.__INITIAL_STATE__ = ${serialize(initialState)}</script>
     ${staticAssets.createAppScript()}

--- a/server/render/static-assets/dev.js
+++ b/server/render/static-assets/dev.js
@@ -1,18 +1,16 @@
-import { trackingID } from '../../../app/config/app';
 import favicon from '../../../app/images/favicon.png';
 
 const createAppScript = () => '<script async type="text/javascript" charset="utf-8" src="/assets/app.js"></script>';
 
-const createAnalyticsSnippet = id =>
-  `<script>
-window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-ga('create', '${id}', 'auto');
-ga('send', 'pageview');
-</script>
-<script async src='https://www.google-analytics.com/analytics.js'></script>
+const createTagManagerSnippet = id => `
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${id}');</script>
 `;
 
-const createTrackingScript = () => (trackingID ? createAnalyticsSnippet(trackingID) : '');
+const createTrackingScript = trackingID => (trackingID ? createTagManagerSnippet(trackingID) : '');
 
 const createStylesheets = () => `
 <link rel="shortcut icon" href="${favicon}" />

--- a/server/render/static-assets/prod.js
+++ b/server/render/static-assets/prod.js
@@ -1,19 +1,17 @@
-import { trackingID } from '../../../app/config/app';
 import favicon from '../../../app/images/favicon.png';
 import assets from '../../../public/assets/manifest.json';
 
 const createAppScript = () => `<script async type="text/javascript" charset="utf-8" src="${assets['app.js']}"></script>`;
 
-const createAnalyticsSnippet = id =>
-  `<script>
-window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-ga('create', '${id}', 'auto');
-ga('send', 'pageview');
-</script>
-<script async src='https://www.google-analytics.com/analytics.js'></script>
+const createTagManagerSnippet = id => `
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${id}');</script>
 `;
 
-const createTrackingScript = () => (trackingID ? createAnalyticsSnippet(trackingID) : '');
+const createTrackingScript = trackingID => (trackingID ? createTagManagerSnippet(trackingID) : '');
 
 const createStylesheets = () => `
 <link rel="shortcut icon" href="${favicon}" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,6 +13,10 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
 
+"@redux-beacon/google-tag-manager@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@redux-beacon/google-tag-manager/-/google-tag-manager-1.0.1.tgz#ba3f6ee6f5495933a6fddf08e8071d30b4cf0e13"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -190,6 +194,10 @@ acorn@^5.0.0, acorn@^5.5.0, acorn@^5.6.2:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
+ajv-errors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.0.tgz#ecf021fa108fd17dfb5e6b383f2dd233e31ffc59"
+
 ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
@@ -343,6 +351,10 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
 
+array-flatten@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.1.tgz#426bb9da84090c1838d812c8150af20a8331e296"
+
 array-includes@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
@@ -432,7 +444,7 @@ async@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.4, async@^2.4.1, async@^2.6.0:
+async@^2.1.4, async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:
@@ -2871,15 +2883,6 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-text-webpack-plugin@4.0.0-beta.0:
-  version "4.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/extract-text-webpack-plugin/-/extract-text-webpack-plugin-4.0.0-beta.0.tgz#f7361d7ff430b42961f8d1321ba8c1757b5d4c42"
-  dependencies:
-    async "^2.4.1"
-    loader-utils "^1.1.0"
-    schema-utils "^0.4.5"
-    webpack-sources "^1.1.0"
-
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -4811,6 +4814,14 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
+mini-css-extract-plugin@^0.4.2:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.4.tgz#c10410a004951bd3cedac1da69053940fccb625d"
+  dependencies:
+    loader-utils "^1.1.0"
+    schema-utils "^1.0.0"
+    webpack-sources "^1.1.0"
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -6287,6 +6298,12 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
+redux-beacon@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/redux-beacon/-/redux-beacon-2.0.3.tgz#9b057aa9521af6225a1b8f60175c85e3ba29a629"
+  dependencies:
+    array-flatten "2.1.1"
+
 redux-logger@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
@@ -6652,6 +6669,14 @@ schema-utils@^0.4.3, schema-utils@^0.4.4, schema-utils@^0.4.5:
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
 
+schema-utils@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
+  dependencies:
+    ajv "^6.1.0"
+    ajv-errors "^1.0.0"
+    ajv-keywords "^3.1.0"
+
 scoped-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-1.0.0.tgz#a346bb1acd4207ae70bd7c0c7ca9e566b6baddb8"
@@ -6695,7 +6720,7 @@ send@0.16.2:
     range-parser "~1.2.0"
     statuses "~1.4.0"
 
-serialize-javascript@^1.4.0:
+serialize-javascript@^1.4.0, serialize-javascript@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.5.0.tgz#1aa336162c88a890ddad5384baebc93a655161fe"
 


### PR DESCRIPTION
## Using redux-beacon for Google Tag Manager event handling

I've replaced Michael's custom implementation for Google Tag Manager event handling (in app/utils/gtmMiddleware.js) with redux-beacon which simplifies the code a lot and should make it easier to maintain and add more events to future builds.

I've brought over some things from Absolute Cosmetic's code to get the trackingId from App Settings and also replaced the Google Analytics snippet with the Google Tag Manager snippet.

This should also add the GTM scripts/snippets in the right places on the DOM when you add a GTM Tracking ID in the App Settings in WordPress.

Hoping this PR will help standardise the GTM scripts positioning as well.